### PR TITLE
Change function coefTable.survreg

### DIFF
--- a/R/coefTable.R
+++ b/R/coefTable.R
@@ -42,6 +42,9 @@ function(model, ...) {
 }
 
 `coefTable.survreg` <-
+function(model, ...)
+        .makeCoefTable(c(coef(model),model$scale), sqrt(diag(vcov(model, ...))), model$df.residual)
+
 `coefTable.lm` <-
 function(model, ...)
 	.makeCoefTable(coef(model), sqrt(diag(vcov(model, ...))), model$df.residual)

--- a/R/coefTable.R
+++ b/R/coefTable.R
@@ -43,7 +43,7 @@ function(model, ...) {
 
 `coefTable.survreg` <-
 function(model, ...)
-        .makeCoefTable(c(coef(model),model$scale), sqrt(diag(vcov(model, ...))), model$df.residual)
+        .makeCoefTable(c(coef(model),log(model$scale)), sqrt(diag(vcov(model, ...))), model$df.residual)
 
 `coefTable.lm` <-
 function(model, ...)


### PR DESCRIPTION
Change function `coefTable.survreg`, so that the scale argument of a survreg model is also taken into account
